### PR TITLE
Remove upper cap for python versions before Python 4

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ packages =
     nx_config
     nx_config.test_utils
     nx_config._core
-python_requires = >=3.6, <3.10
+python_requires = >=3.6, <4.0
 install_requires = 
     python-dateutil >= 2.8.2, < 3
     pyyaml >= 6.0, < 7


### PR DESCRIPTION
Ref #33 